### PR TITLE
Add afterLoad handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,16 @@ schemaWidgets.SchemaWidgets = function(options, callback) {
 };
 ```
 
+If you need to fetch more data that is dependent on all of the joins being hydrated,
+you can execute custom code after the widget is finished loading in your `index.js`:
+
+```javascript
+self.widgets.menuBuilder.afterLoad = function(req, item, callback) {
+  // Fetch more data
+  return callback(null);
+}
+```
+
 You also have `afterConvertFields` available to you for treating fields after they are sanitized.  You can use it in `index.js` like this:
 
 ```javascript
@@ -152,4 +162,3 @@ self.widgets.menuBuilder.afterConvertFields = function(req, item, callback) {
   return callback(null);
 }
 ```
-

--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@ function Construct(options, callback) {
     widget.label = options.label || options.name;
     widget.css = options.css || apos.cssName(options.name);
     widget.icon = options.icon;
+    widget.afterLoad = options.afterLoad;
 
     if (_.find(options.schema, function(field) {
       return (field.name === 'content');
@@ -94,8 +95,14 @@ function Construct(options, callback) {
     widget.loadNow = function(req, items, callback) {
       req.aposSchemaWidgetLoading = true;
       return self._schemas.join(req, options.schema, items, undefined, function(err) {
-        req.aposSchemaWidgetLoading = false;
-        return setImmediate(_.partial(callback, err));
+        if (err || typeof widget.afterLoad !== 'function'){
+          req.aposSchemaWidgetLoading = false;
+          return setImmediate(_.partial(callback, err));
+        }
+        return widget.afterLoad(req, items, function(err) {
+          req.aposSchemaWidgetLoading = false;
+          return setImmediate(_.partial(callback, err));
+        });
       });
     };
     apos.addWidgetType(widget.name, widget);

--- a/index.js
+++ b/index.js
@@ -40,7 +40,10 @@ function Construct(options, callback) {
     widget.label = options.label || options.name;
     widget.css = options.css || apos.cssName(options.name);
     widget.icon = options.icon;
-    widget.afterLoad = options.afterLoad;
+
+    if (options.afterLoad) {
+      widget.afterLoad = options.afterLoad;
+    }
 
     if (_.find(options.schema, function(field) {
       return (field.name === 'content');
@@ -99,7 +102,7 @@ function Construct(options, callback) {
           req.aposSchemaWidgetLoading = false;
           return setImmediate(_.partial(callback, err));
         }
-        return widget.afterLoad(req, items, function(err) {
+        return widget.afterLoad(req, items[0], function(err) {
           req.aposSchemaWidgetLoading = false;
           return setImmediate(_.partial(callback, err));
         });


### PR DESCRIPTION
Simply overriding `widget.load` wouldn't always result in the behavior needed if you are dependent on joins being hydrated to do post-load data manipulation. The `widget.afterLoad` handler is completely optional, and can be added either in `app.js` or the `apostrophe-schema-widgets/index.js`.
